### PR TITLE
Use builtin feature (allowing database default)

### DIFF
--- a/django_link_auth/models.py
+++ b/django_link_auth/models.py
@@ -29,7 +29,7 @@ class Hash(models.Model):
     created_at = models.DateTimeField(
         _('Date and time'),
         editable=False,
-        default=now(),
+        auto_now_add=True,
     )
 
     valid = ValidHashManager()


### PR DESCRIPTION
It also fix the fact the value was a constant defined at class declaration time.